### PR TITLE
fix: use dedicated HTTP client for S3 transfers to prevent timeout on large files

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -13,10 +13,11 @@ import (
 
 // Client is an HTTP client for the sdbx API.
 type Client struct {
-	baseURL    string
-	cfSecret   string
-	apiKey     string
-	httpClient *http.Client
+	baseURL        string
+	cfSecret       string
+	apiKey         string
+	httpClient     *http.Client
+	transferClient *http.Client
 }
 
 // New creates a new API client.
@@ -26,6 +27,17 @@ func New(baseURL, cfSecret, apiKey string) *Client {
 		cfSecret:   cfSecret,
 		apiKey:     apiKey,
 		httpClient: &http.Client{Timeout: 60 * time.Second},
+		// transferClient has no hard timeout — large file uploads/downloads
+		// are bounded by the caller's context, not a fixed wall-clock limit.
+		// We only set idle/TLS/response-header timeouts so stalled
+		// connections still fail fast, but active data transfer is unlimited.
+		transferClient: &http.Client{
+			Transport: &http.Transport{
+				TLSHandshakeTimeout:   30 * time.Second,
+				ResponseHeaderTimeout: 120 * time.Second,
+				IdleConnTimeout:       90 * time.Second,
+			},
+		},
 	}
 }
 
@@ -234,7 +246,7 @@ func (c *Client) UploadToS3(ctx context.Context, url string, body io.Reader, siz
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.ContentLength = size
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.transferClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -250,7 +262,7 @@ func (c *Client) DownloadFromS3(ctx context.Context, url string, onProgress func
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.transferClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem

Uploading large files via `sdbx send` fails with:

```
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The upload reaches ~72% on large files (e.g. 200MB+) and then the hard 60-second `http.Client.Timeout` kills the connection.

## Root Cause

In `cli/internal/api/client.go`, a single `http.Client` with `Timeout: 60 * time.Second` was used for **all** HTTP operations — both lightweight JSON API calls and large S3 file transfers.

In Go, `http.Client.Timeout` is a **hard deadline on the entire request lifecycle** (DNS + connect + TLS handshake + send request body + await response headers + read response body). For large file uploads on slower connections, 60 seconds is insufficient.

## Fix

Introduce a separate `transferClient` for S3 upload/download operations:

- **`httpClient`** (unchanged) — 60s hard timeout for lightweight JSON API calls (`/upload/init`, `/pin/upload`, `/auth/*`, etc.)
- **`transferClient`** (new) — no overall `Timeout`; uses granular `Transport`-level timeouts instead:
  - `TLSHandshakeTimeout: 30s` — connection setup
  - `ResponseHeaderTimeout: 120s` — time for server to begin responding
  - `IdleConnTimeout: 90s` — reap stale connections

Active data transfer (reading/writing the body) is **no longer capped** by a wall-clock limit. Cancellation is still available via the caller's `context.Context`.

## Changes

- `cli/internal/api/client.go`: Added `transferClient` field, updated `UploadToS3()` and `DownloadFromS3()` to use it

## Testing

- ✅ `go build ./...` passes
- ✅ `go test ./...` — all existing tests pass
- The fix is backward-compatible: API call behavior is unchanged, only S3 transfer operations get the new client