### PR TITLE
Merge dev into main

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -3,16 +3,8 @@ name: App
 on:
   push:
     branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - '.github/workflows/app.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - '.github/workflows/app.yml'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -2,13 +2,9 @@ name: CLI
 
 on:
   push:
-    paths:
-      - 'cli/**'
-      - '.github/workflows/cli.yml'
+    branches: [main]
   pull_request:
-    paths:
-      - 'cli/**'
-      - '.github/workflows/cli.yml'
+    branches: [main]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -13,10 +13,11 @@ import (
 
 // Client is an HTTP client for the sdbx API.
 type Client struct {
-	baseURL    string
-	cfSecret   string
-	apiKey     string
-	httpClient *http.Client
+	baseURL        string
+	cfSecret       string
+	apiKey         string
+	httpClient     *http.Client
+	transferClient *http.Client
 }
 
 // New creates a new API client.
@@ -26,6 +27,17 @@ func New(baseURL, cfSecret, apiKey string) *Client {
 		cfSecret:   cfSecret,
 		apiKey:     apiKey,
 		httpClient: &http.Client{Timeout: 60 * time.Second},
+		// transferClient has no hard timeout — large file uploads/downloads
+		// are bounded by the caller's context, not a fixed wall-clock limit.
+		// We only set idle/TLS/response-header timeouts so stalled
+		// connections still fail fast, but active data transfer is unlimited.
+		transferClient: &http.Client{
+			Transport: &http.Transport{
+				TLSHandshakeTimeout:   30 * time.Second,
+				ResponseHeaderTimeout: 120 * time.Second,
+				IdleConnTimeout:       90 * time.Second,
+			},
+		},
 	}
 }
 
@@ -234,7 +246,7 @@ func (c *Client) UploadToS3(ctx context.Context, url string, body io.Reader, siz
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.ContentLength = size
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.transferClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -250,7 +262,7 @@ func (c *Client) DownloadFromS3(ctx context.Context, url string, onProgress func
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.transferClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Changes

Brings `dev` branch up to `main`, including:

- **fix: use dedicated HTTP client for S3 transfers to prevent timeout on large files** (PR #14)
  - Fixes `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` on large file uploads/downloads
  - Introduces a separate `transferClient` with no hard wall-clock timeout for S3 operations
  - Keeps the existing 60s timeout for lightweight JSON API calls