### PR TITLE
ci: run all test suites on every PR to main

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -3,16 +3,8 @@ name: App
 on:
   push:
     branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - '.github/workflows/app.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'backend/**'
-      - 'frontend/**'
-      - '.github/workflows/app.yml'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -2,13 +2,9 @@ name: CLI
 
 on:
   push:
-    paths:
-      - 'cli/**'
-      - '.github/workflows/cli.yml'
+    branches: [main]
   pull_request:
-    paths:
-      - 'cli/**'
-      - '.github/workflows/cli.yml'
+    branches: [main]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Problem

PRs that only touch `cli/` files can't merge into `main` because the required status checks (`Backend Tests`, `Frontend Tests`) never run — they were gated by `paths` filters in `app.yml`.

## Fix

Remove `paths` filters from both `app.yml` and `cli.yml` so **all test suites** (Backend, Frontend, CLI) run on every push/PR to `main`, regardless of which files changed.

This ensures the required status checks always report a result and CLI-only PRs (like #14) can merge through to `main`.

## Changes

- `.github/workflows/app.yml` — removed `paths` filter from `push` and `pull_request` triggers
- `.github/workflows/cli.yml` — removed `paths` filter, added `branches: [main]` to match `app.yml`