### PR TITLE
feat: auto-publish Homebrew formula on release

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -112,3 +112,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ env.VERSION }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/cli/.goreleaser.yaml
+++ b/cli/.goreleaser.yaml
@@ -33,3 +33,15 @@ archives:
 
 checksum:
   name_template: "checksums.txt"
+
+brews:
+  - repository:
+      owner: AntonAks
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://securedbx.com"
+    description: "Zero-knowledge file sharing CLI — encrypt, share, self-destruct"
+    license: "MIT"
+    test: |
+      system "#{bin}/sdbx", "version"


### PR DESCRIPTION
## Summary

Configures GoReleaser to automatically push an updated `Formula/sdbx.rb` to [AntonAks/homebrew-tap](https://github.com/AntonAks/homebrew-tap) on every tagged release.

## Changes

- **`cli/.goreleaser.yaml`** — added `brews` section targeting `AntonAks/homebrew-tap`
- **`.github/workflows/cli.yml`** — pass `HOMEBREW_TAP_TOKEN` env var to the GoReleaser release step

## Setup Required

Add a repo secret `HOMEBREW_TAP_TOKEN` in [Settings → Secrets](https://github.com/AntonAks/securedbx/settings/secrets/actions) — a Personal Access Token with `repo` scope so GoReleaser can push to the tap repo.

## How it works

1. Tag a release (`cli/vX.Y.Z`)
2. GoReleaser builds binaries + checksums
3. GoReleaser auto-generates `Formula/sdbx.rb` with correct URLs + SHA256s
4. GoReleaser pushes the updated formula to `homebrew-tap`

## User install

```bash
brew tap AntonAks/tap
brew install sdbx
```