### PR TITLE
ci: trigger workflows on PRs to dev branch

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -2,9 +2,9 @@ name: App
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -2,9 +2,9 @@ name: CLI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
Add `dev` to `branches` filter in both `app.yml` and `cli.yml` so all tests run on PRs targeting `dev`, not just `main`.