### PR TITLE
ci: add tag trigger for CLI release workflow

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -3,6 +3,8 @@ name: CLI
 on:
   push:
     branches: [main, dev]
+    tags:
+      - 'cli/v*'
   pull_request:
     branches: [main, dev]
 


### PR DESCRIPTION
The `push` trigger only had `branches: [main, dev]` which excluded tag pushes entirely. The GoReleaser Release job (`if: startsWith(github.ref, 'refs/tags/cli/v')`) could never trigger.

Adds `tags: ['cli/v*']` so pushing `cli/vX.Y.Z` tags fires the full pipeline (Test → Lint → Release).