### PR TITLE
Merge dev into main (v1.1.0 release prep)

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -3,6 +3,8 @@ name: CLI
 on:
   push:
     branches: [main, dev]
+    tags:
+      - 'cli/v*'
   pull_request:
     branches: [main, dev]
 


### PR DESCRIPTION
Brings main up to date with dev. After merge, tag `cli/v1.1.0` will be re-pushed to trigger the release.

## Included changes
- fix: S3 upload timeout (#14)
- ci: run all tests on every PR (#16)
- feat: auto-publish Homebrew formula (#17)
- ci: trigger on dev branch (#18)
- ci: fix tag trigger for releases (#20)